### PR TITLE
fix(bytA): Remove conflicting commands/feature.md and clean hooks.json

### DIFF
--- a/plugins/bytA/commands/feature.md
+++ b/plugins/bytA/commands/feature.md
@@ -1,4 +1,0 @@
----
-skill: feature
-description: Start a deterministic full-stack feature workflow (Boomerang + Ralph-Loop)
----

--- a/plugins/bytA/hooks/hooks.json
+++ b/plugins/bytA/hooks/hooks.json
@@ -1,6 +1,5 @@
 {
-  "description": "bytA Workflow Engine - Boomerang + Ralph-Loop (v3.1)",
-  "version": "3.1.0",
+  "description": "bytA Workflow Engine - Boomerang + Ralph-Loop (v3.2)",
   "hooks": {
     "UserPromptSubmit": [
       {


### PR DESCRIPTION
Root cause analysis: The SKILL.md hooks (PreToolUse for Edit/Write/Read/Task) never fired because commands/feature.md may have been loaded instead of skills/feature/SKILL.md. The `skill: feature` frontmatter field in commands/feature.md is NOT a documented field and may cause unpredictable behavior.

Per Claude Code docs: "If a skill and a command share the same name, the skill takes precedence." — but having both could still interfere with hook loading.

Changes:
- Remove commands/feature.md (skills/feature/SKILL.md creates the same /bytA:feature command with proper hooks)
- Remove undocumented `version` field from hooks.json top-level

Diagnostic: User must run `/hooks` to verify bytA hooks appear as [Plugin].

https://claude.ai/code/session_01XPpAFUxbR8aL4XBdkhPXYa