### PR TITLE
refactor(bytA): SKILL.md startup-only, skip-advance logic, prompt-bui…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Private Claude Code Plugins for byteAgenten team members.
 | Plugin | Description | Version |
 |--------|-------------|---------|
 | [byt8](./plugins/byt8) | Full-stack development toolkit for Angular 21 + Spring Boot 4 | 7.5.6 |
-| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.3.0 |
+| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.4.0 |
 
 ## Prerequisites
 

--- a/plugins/bytA/.claude-plugin/plugin.json
+++ b/plugins/bytA/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bytA",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Deterministic full-stack development workflow for Angular 21 + Spring Boot 4. Boomerang (agent isolation) + Ralph-Loop (external verification).",
   "author": {
     "name": "byteAgenten"

--- a/plugins/bytA/README.md
+++ b/plugins/bytA/README.md
@@ -1,6 +1,6 @@
 # bytA Plugin
 
-**Version 3.3.0** | Deterministic Orchestration: Boomerang + Ralph-Loop
+**Version 3.4.0** | Deterministic Orchestration: Boomerang + Ralph-Loop
 
 Full-Stack Development Toolkit fuer Angular 21 + Spring Boot 4 mit deterministischem 10-Phasen-Workflow.
 
@@ -144,6 +144,15 @@ Phase 6 nutzt ein Compound-Kriterium (`+` Separator): STATE und GLOB muessen BEI
 Der Stop-Hook (`wf_orchestrator.sh`) prueft GLOB-Kriterien auch im `awaiting_approval` Status.
 Verhindert, dass ein LLM die externe Verifikation umgeht, indem es `status = "awaiting_approval"` setzt,
 bevor der Shell-Orchestrator verifizieren kann. Bei fehlgeschlagenem GLOB → Reset auf `active` → Ralph-Loop.
+
+### Phase Skipping (v3.3.0)
+
+Phase 0 (architect-planner) kann Phasen als `"skipped"` markieren, wenn sie nicht benoetigt werden
+(z.B. keine DB-Aenderungen → Phase 3 skippen). Der Orchestrator (`wf_orchestrator.sh`) erkennt
+pre-geskippte Phasen und ueberspringt sie automatisch — auch ueber APPROVAL-Gates hinweg.
+
+Skippbare Phasen: 1 (Wireframes), 2 (API), 3 (DB), 4 (Backend), 5 (Frontend).
+Nicht skippbar: 0 (Spec), 6 (Tests), 7 (Security), 8 (Review), 9 (Push & PR).
 
 ### Agent-Reports (MD-Dateien)
 

--- a/plugins/bytA/config/phases.conf
+++ b/plugins/bytA/config/phases.conf
@@ -86,3 +86,23 @@ needs_approval() {
 needs_commit() {
   echo "$WIP_COMMIT_PHASES" | grep -qw "$1"
 }
+
+# Find next non-skipped phase after given phase
+# Usage: get_next_active_phase PHASE [WORKFLOW_FILE]
+get_next_active_phase() {
+  local from_phase=$1
+  local wf_file="${2:-.workflow/workflow-state.json}"
+  local next=$((from_phase + 1))
+  local max=${#PHASES[@]}
+
+  while [ $next -lt $max ]; do
+    local ps
+    ps=$(jq -r ".phases[\"$next\"].status // \"pending\"" "$wf_file" 2>/dev/null || echo "pending")
+    if [ "$ps" != "skipped" ]; then
+      echo "$next"
+      return
+    fi
+    next=$((next + 1))
+  done
+  echo "$next"
+}

--- a/plugins/bytA/scripts/wf_prompt_builder.sh
+++ b/plugins/bytA/scripts/wf_prompt_builder.sh
@@ -86,6 +86,25 @@ context.technicalSpec = {"specFile":".workflow/specs/issue-${ISSUE_NUM}-ph00-arc
 
 ## YOUR TASK
 Create a Technical Specification. Apply 5x Warum root cause analysis. Use MCP tools for current docs.
+
+## PHASE SKIPPING (PFLICHT bei nicht benoetigten Phasen!)
+Wenn bestimmte Phasen fuer dieses Issue NICHT benoetigt werden, MUSST du sie JETZT pre-skippen.
+Fuehre fuer JEDE nicht benoetigte Phase einen jq-Befehl aus:
+
+Beispiel (Phase 3 skippen — keine DB-Aenderungen):
+  jq '.phases["3"] = {"name":"postgresql-architect","status":"skipped","reason":"Keine DB-Aenderungen"} | .context.migrations = {"skipped":true,"reason":"Keine DB-Aenderungen"}' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json
+
+Skip-Referenz:
+| Phase | Agent | context-Key | Wann skippen? |
+|-------|-------|-------------|---------------|
+| 1 | ui-designer | wireframes | Keine UI-Aenderungen noetig |
+| 2 | api-architect | apiDesign | Kein neues/geaendertes API |
+| 3 | postgresql-architect | migrations | Keine DB-Aenderungen |
+| 4 | spring-boot-developer | backendImpl | Kein Backend betroffen |
+| 5 | angular-frontend-developer | frontendImpl | Kein Frontend betroffen |
+
+NIEMALS skippen: Phase 0, 6 (Tests), 7 (Security), 8 (Review), 9 (Push & PR).
+Nur Phasen skippen die WIRKLICH nicht benoetigt werden. Der Orchestrator ueberspringt pre-geskippte Phasen automatisch.
 $RETRY_SECTION$HOTFIX_SECTION
 EOF
     ;;
@@ -285,6 +304,24 @@ context.reviewFeedback = {"reviewFile":".workflow/specs/issue-${ISSUE_NUM}-ph08-
 
 ## YOUR TASK
 Independent code quality review. Verify coverage targets. Check SOLID, DRY, KISS.
+$RETRY_SECTION$HOTFIX_SECTION
+EOF
+    ;;
+
+  9)
+    BRANCH=$(jq -r '.branch // "unknown"' "$WORKFLOW_FILE")
+    FROM_BRANCH=$(jq -r '.fromBranch // "main"' "$WORKFLOW_FILE")
+    cat << EOF
+Phase 9: Push & PR for Issue #$ISSUE_NUM: $ISSUE_TITLE
+
+## WORKFLOW CONTEXT
+- Issue: #$ISSUE_NUM - $ISSUE_TITLE
+- Branch: $BRANCH
+- Target Branch: $FROM_BRANCH
+
+## YOUR TASK (KEIN SUBAGENT — wird direkt vom Orchestrator ausgefuehrt)
+Phase 9 wird durch den UserPromptSubmit-Hook gesteuert.
+Sage "Done." und folge den Anweisungen des Hooks.
 $RETRY_SECTION$HOTFIX_SECTION
 EOF
     ;;

--- a/plugins/bytA/scripts/wf_user_prompt.sh
+++ b/plugins/bytA/scripts/wf_user_prompt.sh
@@ -113,36 +113,61 @@ if [ "$STATUS" = "awaiting_approval" ]; then
 
   case $PHASE in
     0)
+      NEXT_PHASE=$(get_next_active_phase "$PHASE" "$WORKFLOW_FILE")
+      NEXT_NAME=$(get_phase_name "$NEXT_PHASE")
+      NEXT_AGENT=$(get_phase_agent "$NEXT_PHASE")
       echo "Der User antwortet auf die Technical Specification (Phase 0)."
       echo ""
       echo "BEI APPROVAL (Ja/OK/Weiter):"
-      echo "  1. jq '.status = \"active\" | .currentPhase = 1' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:ui-designer, 'Phase 1 (Wireframes) fuer Issue #$ISSUE_NUM: $ISSUE_TITLE')"
+      echo "  1. State updaten:"
+      echo "     jq '.status = \"active\" | .currentPhase = $NEXT_PHASE' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
+      echo "  2. Prompt bauen (Bash-Befehl ausfuehren, Output merken):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh $NEXT_PHASE"
+      echo "  3. Agent starten mit dem KOMPLETTEN Output von Schritt 2:"
+      echo "     Task(bytA:$NEXT_AGENT, '<output>')"
       echo ""
       echo "BEI FEEDBACK (Aenderungswuensche):"
       echo "  1. jq '.status = \"active\"' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:architect-planner, 'Revise Phase 0 based on feedback: {USER_FEEDBACK}')"
+      echo "  2. Prompt bauen mit Feedback (Bash-Befehl ausfuehren):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh 0 'USER_FEEDBACK_HIER_EINFUEGEN'"
+      echo "  3. Task(bytA:architect-planner, '<output>')"
       ;;
 
     1)
+      NEXT_PHASE=$(get_next_active_phase "$PHASE" "$WORKFLOW_FILE")
+      NEXT_NAME=$(get_phase_name "$NEXT_PHASE")
+      NEXT_AGENT=$(get_phase_agent "$NEXT_PHASE")
       echo "Der User antwortet auf die Wireframes (Phase 1)."
       echo ""
       echo "BEI APPROVAL (Ja/OK/Weiter):"
-      echo "  1. jq '.status = \"active\" | .currentPhase = 2' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:api-architect, 'Phase 2 (API Design) fuer Issue #$ISSUE_NUM: $ISSUE_TITLE')"
-      echo "  3. Auto-Advance laeuft durch Phasen 2-6 bis Phase 7 (Approval Gate)"
+      echo "  1. State updaten:"
+      echo "     jq '.status = \"active\" | .currentPhase = $NEXT_PHASE' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
+      echo "  2. Prompt bauen (Bash-Befehl ausfuehren, Output merken):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh $NEXT_PHASE"
+      echo "  3. Agent starten mit dem KOMPLETTEN Output von Schritt 2:"
+      echo "     Task(bytA:$NEXT_AGENT, '<output>')"
+      echo "  4. Auto-Advance laeuft durch AUTO-Phasen bis zum naechsten Approval Gate"
       echo ""
       echo "BEI FEEDBACK (Aenderungswuensche):"
       echo "  1. jq '.status = \"active\"' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:ui-designer, 'Revise Phase 1 based on feedback: {USER_FEEDBACK}')"
+      echo "  2. Prompt bauen mit Feedback (Bash-Befehl ausfuehren):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh 1 'USER_FEEDBACK_HIER_EINFUEGEN'"
+      echo "  3. Task(bytA:ui-designer, '<output>')"
       ;;
 
     7)
+      NEXT_PHASE=$(get_next_active_phase "$PHASE" "$WORKFLOW_FILE")
+      NEXT_NAME=$(get_phase_name "$NEXT_PHASE")
+      NEXT_AGENT=$(get_phase_agent "$NEXT_PHASE")
       echo "Der User antwortet auf das Security Audit Ergebnis (Phase 7)."
       echo ""
       echo "BEI APPROVAL (Weiter/OK):"
-      echo "  1. jq '.status = \"active\" | .currentPhase = 8' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:code-reviewer, 'Phase 8 (Code Review) fuer Issue #$ISSUE_NUM: $ISSUE_TITLE')"
+      echo "  1. State updaten:"
+      echo "     jq '.status = \"active\" | .currentPhase = $NEXT_PHASE' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
+      echo "  2. Prompt bauen (Bash-Befehl ausfuehren, Output merken):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh $NEXT_PHASE"
+      echo "  3. Agent starten mit dem KOMPLETTEN Output von Schritt 2:"
+      echo "     Task(bytA:$NEXT_AGENT, '<output>')"
       echo ""
       echo "BEI SECURITY-FIXES:"
       echo "  1. ZUERST State updaten:"
@@ -166,7 +191,9 @@ if [ "$STATUS" = "awaiting_approval" ]; then
       echo ""
       echo "BEI FEEDBACK:"
       echo "  1. jq '.status = \"active\"' .workflow/workflow-state.json > tmp && mv tmp .workflow/workflow-state.json"
-      echo "  2. Task(bytA:code-reviewer, 'Revise Phase 8 based on feedback: {USER_FEEDBACK}')"
+      echo "  2. Prompt bauen mit Feedback (Bash-Befehl ausfuehren):"
+      echo "     ${CLAUDE_PLUGIN_ROOT}/scripts/wf_prompt_builder.sh 8 'USER_FEEDBACK_HIER_EINFUEGEN'"
+      echo "  3. Task(bytA:code-reviewer, '<output>')"
 
       # Option C: Dateipfad-basierte Heuristik + User-Wahl
       FIX_FILES=$(jq -r '.context.reviewFeedback.fixes[]?.file // empty' "$WORKFLOW_FILE" 2>/dev/null || echo "")


### PR DESCRIPTION
…lder integration (v3.4.0)

- SKILL.md radically simplified to startup-only transport layer (~159 lines) Stop hook controls entire workflow after Phase 0 launch
- Skip-advance logic: orchestrator auto-advances past pre-skipped phases, bypassing approval gates (cascading skips supported)
- Phase 0 prompt includes skip instructions for architect-planner
- Approval hooks (wf_user_prompt.sh) use dynamic get_next_active_phase() and wf_prompt_builder.sh instead of hardcoded phase numbers
- Added Phase 9 case to prompt builder for completeness