### PR TITLE
fix(bytA): Hook CWD fix — read cwd from stdin JSON, cd into project root (v3.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Private Claude Code Plugins for byteAgenten team members.
 | Plugin | Description | Version |
 |--------|-------------|---------|
 | [byt8](./plugins/byt8) | Full-stack development toolkit for Angular 21 + Spring Boot 4 | 7.5.6 |
-| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.4.0 |
+| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.5.0 |
 
 ## Prerequisites
 

--- a/plugins/bytA/.claude-plugin/plugin.json
+++ b/plugins/bytA/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bytA",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Deterministic full-stack development workflow for Angular 21 + Spring Boot 4. Boomerang (agent isolation) + Ralph-Loop (external verification).",
   "author": {
     "name": "byteAgenten"

--- a/plugins/bytA/README.md
+++ b/plugins/bytA/README.md
@@ -1,6 +1,6 @@
 # bytA Plugin
 
-**Version 3.4.0** | Deterministic Orchestration: Boomerang + Ralph-Loop
+**Version 3.5.0** | Deterministic Orchestration: Boomerang + Ralph-Loop
 
 Full-Stack Development Toolkit fuer Angular 21 + Spring Boot 4 mit deterministischem 10-Phasen-Workflow.
 
@@ -144,6 +144,15 @@ Phase 6 nutzt ein Compound-Kriterium (`+` Separator): STATE und GLOB muessen BEI
 Der Stop-Hook (`wf_orchestrator.sh`) prueft GLOB-Kriterien auch im `awaiting_approval` Status.
 Verhindert, dass ein LLM die externe Verifikation umgeht, indem es `status = "awaiting_approval"` setzt,
 bevor der Shell-Orchestrator verifizieren kann. Bei fehlgeschlagenem GLOB → Reset auf `active` → Ralph-Loop.
+
+### Hook CWD Fix (v3.5.0)
+
+Alle Hook-Scripts lesen `cwd` aus dem Hook-Input-JSON (stdin) und wechseln ins Projekt-Root
+bevor sie auf `.workflow/` zugreifen. Claude Code kann Hooks von einem beliebigen Working Directory
+starten — ohne diesen Fix finden die Scripts die Workflow-Dateien nicht und beenden sich lautlos.
+
+Der Stop-Hook (`wf_orchestrator.sh`) loggt zusaetzlich nach `/tmp/bytA-orchestrator-debug.log`
+fuer Fehlerdiagnose (CWD vorher/nachher, Workflow-Datei-Existenz, ERR-Trap mit Zeilennummer).
 
 ### Phase Skipping (v3.3.0)
 

--- a/plugins/bytA/scripts/block_orchestrator_code_edit.sh
+++ b/plugins/bytA/scripts/block_orchestrator_code_edit.sh
@@ -9,7 +9,11 @@
 # Skill-scoped Hook → feuert NUR fuer Orchestrator, NICHT fuer Subagents
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
 INPUT=$(cat)
+_HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file // ""')
 
 # Kein Dateipfad → durchlassen

--- a/plugins/bytA/scripts/block_orchestrator_code_read.sh
+++ b/plugins/bytA/scripts/block_orchestrator_code_read.sh
@@ -9,7 +9,11 @@
 # Skill-scoped Hook → feuert NUR fuer Orchestrator, NICHT fuer Subagents
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
 INPUT=$(cat)
+_HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
 
 # Kein Dateipfad → durchlassen

--- a/plugins/bytA/scripts/block_orchestrator_explore.sh
+++ b/plugins/bytA/scripts/block_orchestrator_explore.sh
@@ -9,7 +9,11 @@
 # Skill-scoped Hook → feuert NUR fuer Orchestrator, NICHT fuer Subagents
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
 INPUT=$(cat)
+_HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 SUBAGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // ""')
 
 # Kein subagent_type → kein Task-Aufruf → durchlassen

--- a/plugins/bytA/scripts/guard_git_push.sh
+++ b/plugins/bytA/scripts/guard_git_push.sh
@@ -6,7 +6,11 @@
 # AUSSER pushApproved=true in workflow-state.json gesetzt ist.
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
 INPUT=$(cat)
+_HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
 # Kein Bash-Befehl → durchlassen

--- a/plugins/bytA/scripts/session_recovery.sh
+++ b/plugins/bytA/scripts/session_recovery.sh
@@ -12,13 +12,22 @@
 # 2. Es soll /bytA:feature aufrufen (damit SKILL.md geladen wird)
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
+_HOOK_INPUT=$(cat)
+_HOOK_CWD=$(echo "$_HOOK_INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 set -e
 
 WORKFLOW_DIR=".workflow"
 WORKFLOW_FILE="${WORKFLOW_DIR}/workflow-state.json"
 
-# Source phase configuration (Single Source of Truth fuer Phase-Namen)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source phase configuration (CLAUDE_PLUGIN_ROOT bevorzugt)
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/scripts"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/../config/phases.conf"
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/plugins/bytA/scripts/subagent_done.sh
+++ b/plugins/bytA/scripts/subagent_done.sh
@@ -6,6 +6,11 @@
 # KEIN LLM beteiligt — rein shell-basiert.
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
+_HOOK_INPUT=$(cat)
+_HOOK_CWD=$(echo "$_HOOK_INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 set -e
 
 WORKFLOW_DIR=".workflow"
@@ -16,8 +21,12 @@ if [ ! -f "$WORKFLOW_FILE" ]; then
   exit 0
 fi
 
-# Source phase configuration
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source phase configuration (CLAUDE_PLUGIN_ROOT bevorzugt)
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/scripts"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/../config/phases.conf"
 
 STATUS=$(jq -r '.status // "unknown"' "$WORKFLOW_FILE" 2>/dev/null || echo "unknown")

--- a/plugins/bytA/scripts/wf_prompt_builder.sh
+++ b/plugins/bytA/scripts/wf_prompt_builder.sh
@@ -17,8 +17,12 @@ PHASE=$1
 HOTFIX_FEEDBACK="${2:-}"
 WORKFLOW_FILE=".workflow/workflow-state.json"
 
-# Source phase configuration
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source phase configuration (CLAUDE_PLUGIN_ROOT bevorzugt)
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/scripts"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/../config/phases.conf"
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/plugins/bytA/scripts/wf_user_prompt.sh
+++ b/plugins/bytA/scripts/wf_user_prompt.sh
@@ -12,14 +12,23 @@
 # BASH 3.x KOMPATIBEL (macOS default)
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Hook CWD fix: cd ins Projekt-Root aus Hook-Input
+_HOOK_INPUT=$(cat)
+_HOOK_CWD=$(echo "$_HOOK_INPUT" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$_HOOK_CWD" ] && [ -d "$_HOOK_CWD" ] && cd "$_HOOK_CWD"
+
 set -e
 
 WORKFLOW_DIR=".workflow"
 WORKFLOW_FILE="${WORKFLOW_DIR}/workflow-state.json"
 LOGS_DIR="${WORKFLOW_DIR}/logs"
 
-# Source phase configuration
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source phase configuration (CLAUDE_PLUGIN_ROOT bevorzugt)
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/scripts"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/../config/phases.conf"
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/plugins/bytA/scripts/wf_verify.sh
+++ b/plugins/bytA/scripts/wf_verify.sh
@@ -21,8 +21,12 @@ set -e
 PHASE=$1
 WORKFLOW_FILE=".workflow/workflow-state.json"
 
-# Source phase configuration
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Source phase configuration (CLAUDE_PLUGIN_ROOT bevorzugt)
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  SCRIPT_DIR="${CLAUDE_PLUGIN_ROOT}/scripts"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+fi
 source "${SCRIPT_DIR}/../config/phases.conf"
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/plugins/bytA/skills/feature/SKILL.md
+++ b/plugins/bytA/skills/feature/SKILL.md
@@ -6,7 +6,7 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "mkdir -p .workflow && date -u +\"%Y-%m-%dT%H:%M:%SZ\" > .workflow/bytA-session"
+          command: "_CWD=$(jq -r '.cwd // \".\"'); cd \"$_CWD\" 2>/dev/null || true; mkdir -p .workflow && date -u +\"%Y-%m-%dT%H:%M:%SZ\" > .workflow/bytA-session"
           once: true
     - matcher: "Edit|Write"
       hooks:


### PR DESCRIPTION
All hook scripts now read the cwd field from Claude Code's stdin JSON and cd into it before accessing .workflow/ files. Without this fix, hooks run from an arbitrary working directory and silently exit because they can't find workflow-state.json.

Also adds debug logging to /tmp/bytA-orchestrator-debug.log (CWD before/after, workflow file existence, ERR trap with line numbers) and uses CLAUDE_PLUGIN_ROOT for SCRIPT_DIR instead of dirname $0.