### PR TITLE
fix(bytA): Remove unsupported description fields from hooks.json (v3.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Private Claude Code Plugins for byteAgenten team members.
 | Plugin | Description | Version |
 |--------|-------------|---------|
 | [byt8](./plugins/byt8) | Full-stack development toolkit for Angular 21 + Spring Boot 4 | 7.5.6 |
-| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.5.0 |
+| [bytA](./plugins/bytA) | Deterministic full-stack workflow (Boomerang + Ralph-Loop) | 3.5.1 |
 
 ## Prerequisites
 

--- a/plugins/bytA/.claude-plugin/plugin.json
+++ b/plugins/bytA/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bytA",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Deterministic full-stack development workflow for Angular 21 + Spring Boot 4. Boomerang (agent isolation) + Ralph-Loop (external verification).",
   "author": {
     "name": "byteAgenten"

--- a/plugins/bytA/README.md
+++ b/plugins/bytA/README.md
@@ -1,6 +1,6 @@
 # bytA Plugin
 
-**Version 3.5.0** | Deterministic Orchestration: Boomerang + Ralph-Loop
+**Version 3.5.1** | Deterministic Orchestration: Boomerang + Ralph-Loop
 
 Full-Stack Development Toolkit fuer Angular 21 + Spring Boot 4 mit deterministischem 10-Phasen-Workflow.
 

--- a/plugins/bytA/hooks/hooks.json
+++ b/plugins/bytA/hooks/hooks.json
@@ -1,9 +1,7 @@
 {
-  "description": "bytA Workflow Engine - Boomerang + Ralph-Loop (v3.2)",
   "hooks": {
     "UserPromptSubmit": [
       {
-        "description": "Approval Gate Context Injection + Loop-Prevention Reset",
         "hooks": [
           {
             "type": "command",
@@ -15,7 +13,6 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "description": "Guard: Block git push/PR without pushApproved flag",
         "hooks": [
           {
             "type": "command",
@@ -26,7 +23,6 @@
     ],
     "Stop": [
       {
-        "description": "Deterministic Orchestrator (Ralph-Loop + External Verify)",
         "hooks": [
           {
             "type": "command",
@@ -37,7 +33,6 @@
     ],
     "SessionStart": [
       {
-        "description": "Context Recovery after Overflow - instructs Claude to reload skill",
         "hooks": [
           {
             "type": "command",
@@ -48,7 +43,6 @@
     ],
     "SubagentStop": [
       {
-        "description": "Deterministic WIP Commits (no LLM)",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
…5.1)

Strip description fields from matcher-group level in hooks.json. These fields are not part of the documented hook schema and may cause Claude Code to silently reject the entire hooks.json file. The working ralph-loop plugin (by Anthropic) does not use these fields.